### PR TITLE
#dropthedot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# A goody-bag of nifty plugins for [Py.Test](https://pytest.org)
+# A goody-bag of nifty plugins for [pytest](https://pytest.org)
 
 [![Circle CI](https://circleci.com/gh/manahl/pytest-plugins.svg?style=shield)](https://circleci.com/gh/manahl/pytest-plugins)
 


### PR DESCRIPTION
Joking aside, the official name for pytest should be `pytest`, all lower cases, no dots.

Thanks for the project! 😁