### PR TITLE
Replace path.py with path

### DIFF
--- a/pytest-git/README.md
+++ b/pytest-git/README.md
@@ -25,7 +25,7 @@ Here's a noddy test case that shows it working:
 ```python
 def test_git_repo(git_repo):
     # The fixture derives from `workspace` in `pytest-shutil`, so they contain 
-    # a handle to the path.py path object (see https://pathpy.readthedocs.io/)
+    # a handle to the path `path` object (see https://path.readthedocs.io/)
     path = git_repo.workspace
     file = path / 'hello.txt'
     file.write_text('hello world!')

--- a/pytest-pyramid-server/README.md
+++ b/pytest-pyramid-server/README.md
@@ -51,7 +51,7 @@ Here's a noddy test case showing the main functionality:
         # POST a document to the server.
         assert pyramid_server.post('/login', 'guest:password123').response_code == 200
         
-        # ``path.py`` path object to the running config file
+        # path ``path`` object to the running config file (see https://path.readthedocs.io/)
         assert pyramid_server.working_config.endswith('testing.ini')
 ```        
         

--- a/pytest-server-fixtures/README.md
+++ b/pytest-server-fixtures/README.md
@@ -115,7 +115,7 @@ All test fixtures share the following properties at runtime:
 | `hostname`  | Hostname that server is listening on
 | `port`      | Port number that the server is listening on
 | `dead`      | True/False: am I dead yet?
-| `workspace` | `path.py` object for the temporary directory the server is running out of
+| `workspace` | [`path`](https://path.readthedocs.io/) object for the temporary directory the server is running out of
 
 ## MongoDB
 

--- a/pytest-shutil/README.md
+++ b/pytest-shutil/README.md
@@ -23,7 +23,7 @@ The workspace fixture is simply a temporary directory at function-scope with a f
     pytest_plugins = ['pytest_shutil']
     
     def test_something(workspace):
-        # Workspaces contain a handle to the path.py path object (see https://pathpy.readthedocs.io/)
+        # Workspaces contain a handle to the path `path` object (see https://path.readthedocs.io/)
         path = workspace.workspace         
         script = path / 'hello.sh'
         script.write_text('#!/bin/sh\n echo hello world!')

--- a/pytest-shutil/setup.py
+++ b/pytest-shutil/setup.py
@@ -25,7 +25,7 @@ install_requires = ['six',
                     'execnet',
                     'contextlib2;python_version<"3"',
                     'pytest',
-                    'path.py',
+                    'path',
                     'mock',
                     'termcolor'
                     ]

--- a/pytest-shutil/setup.py
+++ b/pytest-shutil/setup.py
@@ -25,7 +25,8 @@ install_requires = ['six',
                     'execnet',
                     'contextlib2;python_version<"3"',
                     'pytest',
-                    'path',
+                    'path; python_version >= "3.5"',
+                    'path.py; python_version < "3.5",
                     'mock',
                     'termcolor'
                     ]

--- a/pytest-svn/README.md
+++ b/pytest-svn/README.md
@@ -24,7 +24,7 @@ Here's a noddy test case that shows it working:
 ```python
 def test_svn_repo(svn_repo):
     # The fixture derives from `workspace` in `pytest-shutil`, so they contain 
-    # a handle to the path.py path object (see https://pathpy.readthedocs.io/)
+    # a handle to the path `path` object (see https://pathpy.readthedocs.io/)
     path = svn_repo.workspace
     file = path / 'hello.txt'
     file.write_text('hello world!')


### PR DESCRIPTION
Unless there's some obscure backwards-compatibility reason, I think you should import path instead of path.py.

This actually leads to a problem downstream on conda-forge: since the conda-forge path.py package is just a wrapper for path, no package named path.py is installed, leaving pip in an inconsistent state due to this package's explicit dependence on path.py.

https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=286865&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=e5c8ab1d-8ff9-5cae-b332-e15ae582ed2d&l=210