### PR TITLE
Escape backslash to suppress DeprecationWarning

### DIFF
--- a/pytest-profiling/pytest_profiling.py
+++ b/pytest-profiling/pytest_profiling.py
@@ -17,7 +17,7 @@ LARGE_FILENAME_HASH_LEN = 8
 
 
 def clean_filename(s):
-    forbidden_chars = set('/?<>\\b:*|"')
+    forbidden_chars = set('/?<>\\:*|"')
     return six.text_type("".join(c if c not in forbidden_chars and ord(c) < 127 else '_'
                                  for c in s))
 

--- a/pytest-profiling/pytest_profiling.py
+++ b/pytest-profiling/pytest_profiling.py
@@ -17,7 +17,7 @@ LARGE_FILENAME_HASH_LEN = 8
 
 
 def clean_filename(s):
-    forbidden_chars = set('/?<>\:*|"')
+    forbidden_chars = set('/?<>\\b:*|"')
     return six.text_type("".join(c if c not in forbidden_chars and ord(c) < 127 else '_'
                                  for c in s))
 


### PR DESCRIPTION
Python raises `DeprecationWarning: invalid escape sequence \:`

Since `\:` are clearly meant to indicate 2 forbidden chars rather than an escape sequence, I escaped the backslash.