### PR TITLE
devpi now requires devpi-init for initialization.

### DIFF
--- a/pytest-devpi-server/_pytest_devpi_server/__init__.py
+++ b/pytest-devpi-server/_pytest_devpi_server/__init__.py
@@ -121,9 +121,8 @@ class DevpiServer(HTTPTestServer):
             log.info("Extracting initial server data from {}".format(self.data))
             zipfile.ZipFile(self.data, 'r').extractall(self.server_dir)
         else:
-            self.run([sys.executable, '-c', 'import sys; from devpi_server.main import main; sys.exit(main())',
+            self.run([sys.exec_prefix + "/bin/devpi-init",
                     '--serverdir', self.server_dir,
-                    '--init',
                     ])
 
 

--- a/pytest-devpi-server/_pytest_devpi_server/__init__.py
+++ b/pytest-devpi-server/_pytest_devpi_server/__init__.py
@@ -121,7 +121,7 @@ class DevpiServer(HTTPTestServer):
             log.info("Extracting initial server data from {}".format(self.data))
             zipfile.ZipFile(self.data, 'r').extractall(self.server_dir)
         else:
-            self.run([sys.exec_prefix + "/bin/devpi-init",
+            self.run([os.path.join(sys.exec_prefix, "bin", "devpi-init"),
                     '--serverdir', self.server_dir,
                     ])
 

--- a/pytest-devpi-server/tests/integration/test_devpi_server.py
+++ b/pytest-devpi-server/tests/integration/test_devpi_server.py
@@ -6,6 +6,7 @@ NEW_INDEX = {
         u"acl_upload": [u"testuser"],
         u"bases": [],
         u"mirror_whitelist": [],
+        u"mirror_whitelist_inheritance": u"intersection",
         u"projects": [],
         u"type": u"stage",
         u"volatile": True,


### PR DESCRIPTION
Fixture now initializes properly.
See https://pypi.org/project/devpi-server/5.2.0/ for information on why these changes (or similar) are necessary.

Addresses #179 