### PR TITLE
pytest-server-fixtures: Explicitly close initial Mongo client

### DIFF
--- a/pytest-server-fixtures/pytest_server_fixtures/mongo.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/mongo.py
@@ -127,9 +127,9 @@ class MongoTestServer(TestServerV2):
 
         log.info("Connecting to Mongo at %s:%s" % (self.hostname, self.port))
         try:
-            self.api = pymongo.MongoClient(self.hostname, self.port,
-                                           serverselectiontimeoutms=200)
-            self.api.list_database_names()
+            with pymongo.MongoClient(self.hostname, self.port, serverselectiontimeoutms=200) as initial_api:
+                initial_api.list_database_names()
+
             # Configure the client with default timeouts in case the server goes slow
             self.api = pymongo.MongoClient(self.hostname, self.port)
             return True


### PR DESCRIPTION
When checking the Mongo server has come up properly, the `MongoTestServer`
class first creates a `pymongo.MongoClient` with a short timeout to avoid
waiting a long time in the failure case. After this it creates another
client with the default timeouts, but prior to this change, the initial
client is not closed.

This change explicitly closes the initial client after use.