### PR TITLE
setDaemon is deprecated

### DIFF
--- a/pytest-server-fixtures/pytest_server_fixtures/base.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/base.py
@@ -104,7 +104,7 @@ class ProcessReader(threading.Thread):
         self.process = process
         self.stream = stream
         super(ProcessReader, self).__init__()
-        self.setDaemon(True)
+        self.daemon = True
 
     def run(self):
         while self.process.poll() is None:


### PR DESCRIPTION
Thanks for the nice project. 

I am getting deprecation warnings running the `s3_bucket` fixture; here's a small PR to fix that. 

The new way to do this is to `daemon = True`