### PR TITLE
Fixed S3 bucket doc

### DIFF
--- a/pytest-server-fixtures/README.md
+++ b/pytest-server-fixtures/README.md
@@ -222,7 +222,7 @@ Here's an example on how to run up one of these servers:
 
 ```python
 def test_connection(s3_bucket):
-    bucket = s3_bucket.client.Bucket(s3_bucket.bucket_name)
+    bucket = s3_bucket.client.Bucket(s3_bucket.name)
     assert bucket is not None
 ```
 


### PR DESCRIPTION
The example incorrectly uses `bucket_name` instead of `name` to get the bucket UUID.