### PR TITLE
Use `pypandoc.convert_text` instead of `pypandoc.convert`

### DIFF
--- a/common_setup.py
+++ b/common_setup.py
@@ -51,8 +51,8 @@ def common_setup(src_dir):
     # Convert Markdown to RST for PyPI
     try:
         import pypandoc
-        long_description = pypandoc.convert(readme_file, 'rst')
-        changelog = pypandoc.convert(changelog_file, 'rst')
+        long_description = pypandoc.convert_text(readme_file, 'rst', format='md')
+        changelog = pypandoc.convert_text(changelog_file, 'rst', format='md')
     except (IOError, ImportError, OSError):
         long_description = open(readme_file).read()
         changelog = open(changelog_file).read()


### PR DESCRIPTION
Currently, pypandoc does not have `convert` function. https://github.com/NicklasTegner/pypandoc/blob/master/pypandoc/__init__.py
pypandoc only has `convert_file` or `convert_text`.

Actually pypandoc previously have `convert` function like https://github.com/NicklasTegner/pypandoc/blob/c06d7b64a58729fa174b7721dac6c600fad166af/pypandoc/__init__.py

Related issue  https://github.com/man-group/pytest-plugins/issues/87