### PR TITLE
Fix forcing color through termcolor

### DIFF
--- a/pytest-shutil/pytest_shutil/cmdline.py
+++ b/pytest-shutil/pytest_shutil/cmdline.py
@@ -52,6 +52,8 @@ def chdir(dirname):
 class PrettyFormatter(object):
     def __init__(self, color=True):
         from termcolor import colored
+        if color is False:
+            os.environ["FORCE_COLOR"] = "true"
         self.color = color
         self.colored = colored
         self.buffer = []

--- a/pytest-shutil/tests/unit/test_cmdline.py
+++ b/pytest-shutil/tests/unit/test_cmdline.py
@@ -10,7 +10,8 @@ def test_umask(workspace):
         f.touch()
     assert (f.stat().st_mode & 0o777) == 0o464
 
-def test_pretty_formatter():
+def test_pretty_formatter(monkeypatch):
+    monkeypatch.setenv("FORCE_COLOR", "1")
     f = cmdline.PrettyFormatter()
     f.title('A Title')
     f.hr()


### PR DESCRIPTION
Since termcolor 2.1.0, the library will now detect whether or not the process is running a TTY and disable outputting color if so. This broke using the `--color` argument to force color when piping to another process (e.g. `less`), as well as our pytest function for checking rendered output.

The fix is ensuring that we set the environment variable FORCE_COLOR in the cases where we want color, and might not have a TTY (e.g. in the pytest, or when using `--color` option).

Fixes #210