### PR TITLE
pytest-server-fixtures: Remove six and future

### DIFF
--- a/pytest-server-fixtures/pytest_server_fixtures/base.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/base.py
@@ -14,8 +14,6 @@ import logging
 import random
 import errno
 
-from six import string_types
-
 from pytest_server_fixtures import CONFIG
 from pytest_shutil.workspace import Workspace
 
@@ -106,13 +104,13 @@ class ProcessReader(threading.Thread):
         self.stderr = stderr
         self.process = process
         self.stream = stream
-        super(ProcessReader, self).__init__()
+        super().__init__()
         self.daemon = True
 
     def run(self):
         while self.process.poll() is None:
             l = self.stream.readline()
-            if not isinstance(l, string_types):
+            if not isinstance(l, str):
                 l = l.decode('utf-8')
 
             if l.strip():

--- a/pytest-server-fixtures/pytest_server_fixtures/http.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/http.py
@@ -1,5 +1,4 @@
-from __future__ import print_function
-
+import http.client
 import os
 import socket
 import logging
@@ -9,7 +8,6 @@ import sys
 import pytest
 import requests
 from contextlib import contextmanager
-from six.moves import http_client
 
 from pytest_shutil.env import unset_env
 from pytest_server_fixtures import CONFIG
@@ -83,7 +81,7 @@ class HTTPTestServer(TestServer):
                 with self.handle_proxy():
                     returned = requests.get('http://%s:%d/%s' % (self.hostname, self.port, path))
                 return returned.json() if as_json else returned
-            except (http_client.BadStatusLine, requests.ConnectionError) as e:
+            except (http.client.BadStatusLine, requests.ConnectionError) as e:
                 time.sleep(int(i) / 10)
                 pass
         raise e
@@ -109,7 +107,7 @@ class HTTPTestServer(TestServer):
                 with self.handle_proxy():
                     returned = requests.post('http://%s:%d/%s' % (self.hostname, self.port, path), data=data, headers=headers)
                 return returned.json() if as_json else returned
-            except (http_client.BadStatusLine, requests.ConnectionError) as e:
+            except (http.client.BadStatusLine, requests.ConnectionError) as e:
                 time.sleep(int(i) / 10)
                 pass
         raise e

--- a/pytest-server-fixtures/pytest_server_fixtures/jenkins.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/jenkins.py
@@ -9,7 +9,6 @@ import os.path
 import shutil
 
 import pytest
-import six
 
 from pytest_server_fixtures import CONFIG
 from pytest_fixture_config import yield_requires_config
@@ -95,7 +94,7 @@ class JenkinsTestServer(HTTPTestServer):
         if plugins is None:
             plugins = available_plugins.keys()
         else:
-            if isinstance(plugins, six.string_types):
+            if isinstance(plugins, str):
                 plugins = [plugins]
 
             errors = []

--- a/pytest-server-fixtures/pytest_server_fixtures/postgres.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/postgres.py
@@ -8,7 +8,6 @@ import subprocess
 
 import errno
 import pytest
-from six import text_type
 
 from pytest_server_fixtures import CONFIG
 from pytest_fixture_config import requires_config
@@ -65,7 +64,7 @@ class PostgresServer(TestServer):
         try:
             self.pg_bin = subprocess.check_output([CONFIG.pg_config_executable, "--bindir"]).decode('utf-8').rstrip()
         except OSError as e:
-            msg = "Failed to get pg_config --bindir: " + text_type(e)
+            msg = "Failed to get pg_config --bindir: " + str(e)
             print(msg)
             self._fail(msg)
         initdb_path = self.pg_bin + '/initdb'
@@ -76,7 +75,7 @@ class PostgresServer(TestServer):
         try:
             subprocess.check_call([initdb_path, str(self.workspace / 'db')])
         except OSError as e:
-            msg = "Failed to launch postgres: " + text_type(e)
+            msg = "Failed to launch postgres: " + str(e)
             print(msg)
             self._fail(msg)
 

--- a/pytest-server-fixtures/pytest_server_fixtures/s3.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/s3.py
@@ -11,7 +11,6 @@ import logging
 import os
 
 import pytest
-from future.utils import text_type
 from pytest_fixture_config import requires_config
 
 from . import CONFIG
@@ -47,7 +46,7 @@ def s3_bucket(s3_server):  # pylint: disable=redefined-outer-name
     returning a BucketInfo namedtuple with `s3_bucket.client` and `s3_bucket.name` fields
     """
     client = s3_server.get_s3_client()
-    bucket_name = text_type(uuid.uuid4())
+    bucket_name = str(uuid.uuid4())
     client.create_bucket(Bucket=bucket_name)
     return BucketInfo(client, bucket_name)
 
@@ -96,6 +95,6 @@ class MinioServer(HTTPTestServer):
             "server",
             "--address",
             "{}:{}".format(self.hostname, self.port),
-            text_type(self.datadir),
+            str(self.datadir),
         ]
         return cmdargs

--- a/pytest-server-fixtures/setup.py
+++ b/pytest-server-fixtures/setup.py
@@ -20,8 +20,6 @@ classifiers = [
 install_requires = ['pytest',
                     'pytest-shutil',
                     'pytest-fixture-config',
-                    'six',
-                    'future',
                     'requests',
                     'retry',
                     'psutil',


### PR DESCRIPTION
Now that we only support Python 3.6 and above, we can stop using crutches like six and future.