### PR TITLE
fixing import for py 3.11 compatibility

### DIFF
--- a/pytest-verbose-parametrize/pytest_verbose_parametrize.py
+++ b/pytest-verbose-parametrize/pytest_verbose_parametrize.py
@@ -1,7 +1,4 @@
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from collections.abc import Iterable
 from six import string_types, text_type
 
 


### PR DESCRIPTION
removing old import that's not needed since py 3.3
