### PR TITLE
#224: Fix the use of Path, which renamed isdir() to is_dir().

### DIFF
--- a/pytest-devpi-server/_pytest_devpi_server/__init__.py
+++ b/pytest-devpi-server/_pytest_devpi_server/__init__.py
@@ -9,7 +9,6 @@ import zipfile
 import logging
 from six.moves import cStringIO
 
-import pkg_resources
 from pytest import yield_fixture, fixture
 import devpi_server as _devpi_server
 from devpi.main import main as devpi_client
@@ -20,16 +19,16 @@ log = logging.getLogger(__name__)
 
 @yield_fixture(scope='session')
 def devpi_server(request):
-    """ Session-scoped Devpi server run in a subprocess, out of a temp dir. 
+    """ Session-scoped Devpi server run in a subprocess, out of a temp dir.
         Out-of-the-box it creates a single user an index for that user, then
         uses that index.
-        
+
         Methods
         -------
-        api():    Client API method, directly bound to the devpi-client command-line tool.  Examples:   
+        api():    Client API method, directly bound to the devpi-client command-line tool.  Examples:
         ...          api('index', '-c', 'myindex') to create an index called 'myindex'
         ...          api('getjson', '/user/myindex') to return the json string describing this index
-        
+
         Attributes
         ----------
         uri:          Server URI
@@ -38,9 +37,9 @@ def devpi_server(request):
         index:        Initially created index name
         server_dir:   Path to server database
         client_dir:   Path to client directory
-           
-        .. also inherits all attributes from the `workspace` fixture 
-        
+
+        .. also inherits all attributes from the `workspace` fixture
+
         For more fine-grained control over these attributes, use the class directly and pass in
         constructor arguments.
     """
@@ -51,7 +50,7 @@ def devpi_server(request):
 
 @fixture
 def devpi_function_index(request, devpi_server):
-    """ Creates and activates an index for your current test function. 
+    """ Creates and activates an index for your current test function.
     """
     index_name = '/'.join((devpi_server.user, request.function.__name__))
     devpi_server.api('index', '-c', index_name)
@@ -70,7 +69,7 @@ class DevpiServer(HTTPTestServer):
             Run in offline mode. Defaults to True
         data:  `str`
            Filesystem path to a zipfile archive of the initial server data directory.
-           If not set and in offline mode, it uses a pre-canned snapshot of a 
+           If not set and in offline mode, it uses a pre-canned snapshot of a
            newly-created empty server.
         """
         self.debug = debug

--- a/pytest-devpi-server/_pytest_devpi_server/__init__.py
+++ b/pytest-devpi-server/_pytest_devpi_server/__init__.py
@@ -88,7 +88,7 @@ class DevpiServer(HTTPTestServer):
     @property
     def run_cmd(self):
         res = [sys.executable, '-c', 'import sys; from devpi_server.main import main; sys.exit(main())',
-                '--serverdir', self.server_dir,
+                '--serverdir', str(self.server_dir),
                 '--host', self.hostname,
                 '--port', str(self.port)
                 ]
@@ -103,7 +103,7 @@ class DevpiServer(HTTPTestServer):
         """
         client_args = ['devpi']
         client_args.extend(args)
-        client_args.extend(['--clientdir', self.client_dir])
+        client_args.extend(['--clientdir', str(self.client_dir)])
         log.info(' '.join(client_args))
         captured = cStringIO()
         stdout = sys.stdout
@@ -118,10 +118,10 @@ class DevpiServer(HTTPTestServer):
     def pre_setup(self):
         if self.data:
             log.info("Extracting initial server data from {}".format(self.data))
-            zipfile.ZipFile(self.data, 'r').extractall(self.server_dir)
+            zipfile.ZipFile(self.data, 'r').extractall(str(self.server_dir))
         else:
             self.run([os.path.join(sys.exec_prefix, "bin", "devpi-init"),
-                    '--serverdir', self.server_dir,
+                    '--serverdir', str(self.server_dir),
                     ])
 
 

--- a/pytest-devpi-server/setup.py
+++ b/pytest-devpi-server/setup.py
@@ -23,11 +23,8 @@ install_requires = ['pytest-server-fixtures',
                     'devpi-server>=3.0.1',
                     'devpi-client',
                     'six',
-                    'ruamel.yaml>=0.15;python_version == "2.7"',
-                    'ruamel.yaml>=0.15;python_version > "3.4"',
+                    'ruamel.yaml>=0.15',
                     ]
-
-tests_require = []
 
 entry_points = {
     'pytest11': [
@@ -44,7 +41,6 @@ if __name__ == '__main__':
         author_email='eeaston@gmail.com',
         classifiers=classifiers,
         install_requires=install_requires,
-        tests_require=tests_require,
         packages=find_packages(exclude='tests'),
         entry_points=entry_points,
     ))

--- a/pytest-devpi-server/tests/integration/test_devpi_server.py
+++ b/pytest-devpi-server/tests/integration/test_devpi_server.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 NEW_INDEX = {
     u"result": {
@@ -23,7 +24,7 @@ def test_server(devpi_server):
 
 
 def test_upload(devpi_server):
-    pkg_dir = devpi_server.workspace / "pkg"
+    pkg_dir: Path = devpi_server.workspace / "pkg"
     pkg_dir.mkdir(exist_ok=True)
     setup_py = pkg_dir / "setup.py"
     setup_py.write_text(
@@ -33,7 +34,6 @@ setup(name='test-foo',
       version='1.2.3')
 """
     )
-    pkg_dir.chdir()
     devpi_server.api("upload")
     res = devpi_server.api(
         "getjson", "/{}/{}".format(devpi_server.user, devpi_server.index)

--- a/pytest-devpi-server/tests/integration/test_devpi_server.py
+++ b/pytest-devpi-server/tests/integration/test_devpi_server.py
@@ -24,7 +24,7 @@ def test_server(devpi_server):
 
 def test_upload(devpi_server):
     pkg_dir = devpi_server.workspace / "pkg"
-    pkg_dir.mkdir_p()
+    pkg_dir.mkdir(exist_ok=True)
     setup_py = pkg_dir / "setup.py"
     setup_py.write_text(
         """

--- a/pytest-profiling/tests/integration/test_profile_integration.py
+++ b/pytest-profiling/tests/integration/test_profile_integration.py
@@ -19,7 +19,7 @@ def virtualenv():
 
         venv.install_package("pytest-cov")
         venv.install_package("pytest-profiling")
-        copy_tree(test_dir, venv.workspace)
+        copy_tree(str(test_dir), str(venv.workspace))
         shutil.rmtree(
             venv.workspace / "tests" / "unit" / "__pycache__", ignore_errors=True
         )

--- a/pytest-profiling/tests/integration/test_profile_integration.py
+++ b/pytest-profiling/tests/integration/test_profile_integration.py
@@ -44,7 +44,7 @@ def test_profile_generates_svg(pytestconfig, virtualenv):
     assert any(
         [
             "test_example:1:test_foo" in i
-            for i in (virtualenv.workspace / "prof/combined.svg").lines()
+            for i in (virtualenv.workspace / "prof/combined.svg").open().readlines()
         ]
     )
 
@@ -58,7 +58,7 @@ def test_profile_long_name(pytestconfig, virtualenv):
         pytestconfig,
         cd=virtualenv.workspace,
     )
-    assert (virtualenv.workspace / "prof/fbf7dc37.prof").isfile()
+    assert (virtualenv.workspace / "prof/fbf7dc37.prof").is_file()
 
 
 def test_profile_chdir(pytestconfig, virtualenv):

--- a/pytest-pyramid-server/pytest_pyramid_server.py
+++ b/pytest-pyramid-server/pytest_pyramid_server.py
@@ -11,10 +11,7 @@ import glob
 import shutil
 import threading
 
-try:
-    from path import Path
-except ImportError:
-    from path import path as Path
+from pathlib import Path
 
 from wsgiref.simple_server import make_server
 from paste.deploy.loadwsgi import loadapp
@@ -30,16 +27,16 @@ class ConfigNotFoundError(Exception):
 
 @yield_fixture(scope='session')
 def pyramid_server(request):
-    """ Session-scoped Pyramid server run in a subprocess, out of a temp dir. 
+    """ Session-scoped Pyramid server run in a subprocess, out of a temp dir.
         This is a 'real' server that you can point a Selenium webdriver at.
-    
+
         This fixture searches for its configuration in the current working directory
         called 'testing.ini'. All .ini files in the cwd will be copied to the tempdir
-        so that config chaining still works. 
-        
+        so that config chaining still works.
+
         The fixture implementation in `PyramidTestServer` has more flexible configuration
-        options, use it directly to define more fine-grained fixtures. 
-        
+        options, use it directly to define more fine-grained fixtures.
+
         Methods
         -------
         get_config() : Return current configuration as a dict.
@@ -47,11 +44,11 @@ def pyramid_server(request):
         ..             Retry failures by default.
         post()       : Post payload to url relative to the server root.
         ..             Retry failures by default.
-        
+
         Attributes
         ----------
         working_config  (`path.path`): Path to the config file used by the server at runtime
-        .. also inherits all attributes from the `workspace` fixture 
+        .. also inherits all attributes from the `workspace` fixture
     """
     with PyramidTestServer() as server:
         server.start()
@@ -97,7 +94,7 @@ class PyramidTestServer(HTTPTestServer):
         for filename in glob.glob(os.path.join(self.config_dir, '*.ini')):
             shutil.copy(filename, self.workspace)
 
-        Path.copy(self.original_config, self.working_config)
+        shutil.copy(str(self.original_config), str(self.working_config))
 
         parser = configparser.ConfigParser()
         parser.read(self.original_config)

--- a/pytest-pyramid-server/pytest_pyramid_server.py
+++ b/pytest-pyramid-server/pytest_pyramid_server.py
@@ -139,7 +139,7 @@ class InlinePyramidTestServer(PyramidTestServer):
         """
         print('\n==================================================================================')
         print("Starting wsgiref pyramid test server on host %s port %s" % (self.hostname, self.port))
-        wsgi_app = loadapp('config:' + self.working_config)
+        wsgi_app = loadapp('config:' + str(self.working_config))
         self.server = make_server(self.hostname, self.port, wsgi_app)
         worker = threading.Thread(target=self.server.serve_forever)
         worker.daemon = True

--- a/pytest-server-fixtures/pytest_server_fixtures/httpd.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/httpd.py
@@ -1,14 +1,10 @@
 import os
 import platform
-import socket
 import string
 import logging
 
 import pytest
-try:
-    from path import Path
-except ImportError:
-    from path import path as Path
+from pathlib import Path
 
 from pytest_fixture_config import yield_requires_config
 from pytest_server_fixtures import CONFIG

--- a/pytest-server-fixtures/setup.py
+++ b/pytest-server-fixtures/setup.py
@@ -38,7 +38,6 @@ extras_require = {
 }
 
 tests_require = [
-                 'mock; python_version<"3.3"',
                  'psutil',
                  ]
 

--- a/pytest-server-fixtures/tests/integration/test_httpd_proxy_server.py
+++ b/pytest-server-fixtures/tests/integration/test_httpd_proxy_server.py
@@ -11,7 +11,7 @@ def test_start_and_stop(httpd_server):
 
 
 def test_logs(httpd_server):
-    files = [i.basename() for i in httpd_server.log_dir.files()]
+    files = [i.name for i in httpd_server.log_dir.iterdir()]
     for log in ('access.log', 'error.log'):
         assert log in files
 

--- a/pytest-shutil/pytest_shutil/run.py
+++ b/pytest-shutil/pytest_shutil/run.py
@@ -190,7 +190,7 @@ def run_in_subprocess(fn, python=sys.executable, cd=None, timeout=None):
         Raises execnet.RemoteError on exception.
     """
     pkl_fn, preargs = (_evaluate_fn_source, (fn,)) if isinstance(fn, str) else _make_pickleable(fn)
-    spec = '//'.join(filter(None, ['popen', 'python=' + python, 'chdir=' + cd if cd else None]))
+    spec = '//'.join(filter(None, ['popen', 'python=' + python, 'chdir=' + str(cd) if cd else None]))
 
     def inner(*args, **kwargs):
         # execnet sends stdout to /dev/null :(

--- a/pytest-shutil/pytest_shutil/workspace.py
+++ b/pytest-shutil/pytest_shutil/workspace.py
@@ -136,7 +136,7 @@ class Workspace(object):
     def teardown(self):
         if self.delete is not None and not self.delete:
             return
-        if hasattr(self, 'workspace') and self.workspace.isdir():
+        if hasattr(self, 'workspace') and self.workspace.is_dir():
             log.debug("")
             log.debug("=======================================================")
             log.debug("pytest_shutil deleting workspace %s" % self.workspace)

--- a/pytest-shutil/pytest_shutil/workspace.py
+++ b/pytest-shutil/pytest_shutil/workspace.py
@@ -7,13 +7,8 @@ import shutil
 import logging
 import subprocess
 
-try:
-    from path import Path
-except ImportError:
-    from path import path as Path
-
+from pathlib import Path
 import pytest
-from six import string_types
 
 from . import cmdline
 
@@ -23,15 +18,15 @@ log = logging.getLogger(__name__)
 @pytest.yield_fixture()
 def workspace():
     """ Function-scoped temporary workspace that cleans up on exit.
-    
+
     Attributes
     ----------
     workspace (`path.path`):  Path to the workspace directory.
     debug (bool):             If set to True, will log more debug when running commands.
-    delete (bool):            If True, will always delete the workspace on teardown; 
-    ..                        If None, delete the workspace unless teardown occurs via an exception; 
+    delete (bool):            If True, will always delete the workspace on teardown;
+    ..                        If None, delete the workspace unless teardown occurs via an exception;
     ..                        If False, never delete the workspace on teardown.
-        
+
     """
     ws = Workspace()
     yield ws
@@ -99,7 +94,7 @@ class Workspace(object):
         cd : `str`
             Path to chdir to, defaults to workspace root
         """
-        if isinstance(cmd, string_types):
+        if isinstance(cmd, str):
             shell = True
         else:
             # Some of the command components might be path objects or numbers
@@ -116,7 +111,7 @@ class Workspace(object):
                 p = subprocess.Popen(cmd, shell=shell, **kwargs)
             (out, _) = p.communicate()
 
-            if out is not None and not isinstance(out, string_types):
+            if out is not None and not isinstance(out, str):
                 out = out.decode('utf-8')
 
             if self.debug and capture:

--- a/pytest-shutil/setup.py
+++ b/pytest-shutil/setup.py
@@ -21,7 +21,7 @@ install_requires = ['six',
                     'execnet',
                     'contextlib2;python_version<"3"',
                     'pytest',
-                    'path; python_version >= "3.5"',
+                    'path>=16.12.0; python_version >= "3.5"',
                     'path.py; python_version < "3.5"',
                     'mock; python_version<"3.3"',
                     'termcolor'

--- a/pytest-shutil/setup.py
+++ b/pytest-shutil/setup.py
@@ -19,11 +19,7 @@ classifiers = [
 
 install_requires = ['six',
                     'execnet',
-                    'contextlib2;python_version<"3"',
                     'pytest',
-                    'path>=16.12.0; python_version >= "3.5"',
-                    'path.py; python_version < "3.5"',
-                    'mock; python_version<"3.3"',
                     'termcolor'
                     ]
 

--- a/pytest-shutil/tests/unit/test_cmdline.py
+++ b/pytest-shutil/tests/unit/test_cmdline.py
@@ -1,4 +1,3 @@
-import stat
 import os
 
 from pytest_shutil import cmdline
@@ -16,7 +15,7 @@ def test_pretty_formatter():
     f.hr()
     f.p('A Paragraph', 'red')
     assert f.buffer == [
-        '\x1b[1m\x1b[34m  A Title\x1b[0m', 
+        '\x1b[1m\x1b[34m  A Title\x1b[0m',
         '\x1b[1m\x1b[34m--------------------------------------------------------------------------------\x1b[0m',
         '\x1b[31mA Paragraph\x1b[0m'
         ]
@@ -32,8 +31,8 @@ def test_tempdir():
 def test_copy_files(workspace):
     d1 = workspace.workspace / 'd1'
     d2 = workspace.workspace / 'd2'
-    d1.makedirs()
-    d2.makedirs()
+    os.makedirs(d1)
+    os.makedirs(d2)
     (d1 / 'foo').touch()
     (d1 / 'bar').touch()
     cmdline.copy_files(d1, d2)

--- a/pytest-virtualenv/pytest_virtualenv.py
+++ b/pytest-virtualenv/pytest_virtualenv.py
@@ -4,7 +4,6 @@ import os
 import pathlib
 import re
 import shutil
-import subprocess
 import sys
 from enum import Enum
 
@@ -137,7 +136,7 @@ class VirtualEnv(Workspace):
 
         self.env['VIRTUAL_ENV'] = str(self.virtualenv)
 
-        self.env['PATH'] = str(self.python.dirname()) + ((os.path.pathsep + self.env["PATH"])
+        self.env['PATH'] = str(os.path.dirname(self.python)) + ((os.path.pathsep + self.env["PATH"])
                                                          if "PATH" in self.env else "")
         if 'PYTHONPATH' in self.env:
             del(self.env['PYTHONPATH'])


### PR DESCRIPTION
**What**
Replace Path/path.py usages with pathlib.Path across the entire repo. Also removing references to outdated python versions and unused imports. 

**Why**
To address #224 which is currently breaking a number of other builds since the renaming of Path::isdir() to Path::is_dir(). We don't really need the dependency since we can use functions from the standard library.