### PR TITLE
Fix: use extras_requires instead of tests_requires to install pytest-virtualenv

### DIFF
--- a/common_setup.py
+++ b/common_setup.py
@@ -38,7 +38,8 @@ class EggInfo(EggInfoCommand):
     def run(self):
         if self.distribution.extras_require is None:
             self.distribution.extras_require = {}
-        self.distribution.extras_require['tests'] = self.distribution.tests_require
+        if 'tests' not in self.distribution.extras_require and hasattr(self.distribution, 'tests_require'):
+            self.distribution.extras_require['tests'] = self.distribution.tests_require
         EggInfoCommand.run(self)
 
 

--- a/pytest-virtualenv/setup.py
+++ b/pytest-virtualenv/setup.py
@@ -25,9 +25,9 @@ install_requires = ['pytest-fixture-config',
                     'importlib-metadata',
                     ]
 
-tests_require = [
-                 'mock; python_version<"3.3"'
-                 ]
+extras_require = {
+    'test': ['mock; python_version<"3.3"'],
+}
 
 entry_points = {
     'pytest11': [
@@ -44,7 +44,7 @@ if __name__ == '__main__':
         author_email='eeaston@gmail.com',
         classifiers=classifiers,
         install_requires=install_requires,
-        tests_require=tests_require,
+        extras_require=extras_require,
         py_modules=['pytest_virtualenv'],
         entry_points=entry_points,
     ))


### PR DESCRIPTION
Currently, installation of `pytest-virtualenv` plugin fails due to outdated usage of setuptools.
<details>
<summary> Error trace </summary>

```
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [46 lines of output]
      /tmp/pip-install-4nhyz4jn/pytest-virtualenv_93370f578ce6437fa8e558311740de5f/common_setup.py:6: SetuptoolsDeprecationWarning: The test command is disabled and references to it are deprecated.
      !!
      
              ********************************************************************************
              Please remove any references to `setuptools.command.test` in all supported versions of the affected package.
      
              By 2024-Nov-15, you need to update your project and remove deprecated calls
              or your builds will no longer be supported.
              ********************************************************************************
      
      !!
        from setuptools.command.test import test as TestCommand
      /tmp/pip-build-env-ufxf_2sr/overlay/lib/python3.9/site-packages/setuptools/_distutils/dist.py:261: UserWarning: Unknown distribution option: 'tests_require'
        warnings.warn(msg)
      running egg_info
      Traceback (most recent call last):
        File "/home/ysem/.pyenv/versions/3.9.19/envs/coord-conv/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/home/ysem/.pyenv/versions/3.9.19/envs/coord-conv/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/home/ysem/.pyenv/versions/3.9.19/envs/coord-conv/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-ufxf_2sr/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 332, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
        File "/tmp/pip-build-env-ufxf_2sr/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 302, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-ufxf_2sr/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 503, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/tmp/pip-build-env-ufxf_2sr/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 318, in run_setup
          exec(code, locals())
        File "<string>", line 51, in <module>
        File "/tmp/pip-build-env-ufxf_2sr/overlay/lib/python3.9/site-packages/setuptools/__init__.py", line 117, in setup
          return distutils.core.setup(**attrs)
        File "/tmp/pip-build-env-ufxf_2sr/overlay/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 184, in setup
          return run_commands(dist)
        File "/tmp/pip-build-env-ufxf_2sr/overlay/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 200, in run_commands
          dist.run_commands()
        File "/tmp/pip-build-env-ufxf_2sr/overlay/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 954, in run_commands
          self.run_command(cmd)
        File "/tmp/pip-build-env-ufxf_2sr/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 950, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-ufxf_2sr/overlay/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 973, in run_command
          cmd_obj.run()
        File "/tmp/pip-install-4nhyz4jn/pytest-virtualenv_93370f578ce6437fa8e558311740de5f/common_setup.py", line 41, in run
          self.distribution.extras_require['tests'] = self.distribution.tests_require
      AttributeError: 'Distribution' object has no attribute 'tests_require'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.

```
</details>

This PR fixes installation by using `extras_require` instead of `tests_require` which was deprecated long time ago.
