### PR TITLE
pytest-listener: Use py_modules in setup.py

### DIFF
--- a/pytest-listener/setup.py
+++ b/pytest-listener/setup.py
@@ -41,7 +41,7 @@ if __name__ == '__main__':
         classifiers=classifiers,
         install_requires=install_requires,
         tests_require=tests_require,
-        packages=find_packages(exclude='tests'),
+        py_modules=['pytest_listener'],
         entry_points=entry_points,
     ))
     setup(**kwargs)


### PR DESCRIPTION
This package does not use a package directory, so when building a wheel, no code is included. Use the correct keyword, py_modules.