### PR TITLE
pytest-server-fixtures: Correct httpd command line

### DIFF
--- a/pytest-server-fixtures/pytest_server_fixtures/httpd.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/httpd.py
@@ -162,7 +162,7 @@ class HTTPDServer(HTTPTestServer):
 
     @property
     def run_cmd(self):
-        return [CONFIG.httpd_executable, '-f', self.config]
+        return [CONFIG.httpd_executable, '-f', str(self.config)]
 
     def kill(self, retries=5):
         pid = self.pid


### PR DESCRIPTION
Now that the config file we create is a pathlib.Path object, we must convert it to a string before we try and use it, so do so.