### PR TITLE
pytest-server-fixtures: Support large pids in xvfb

### DIFF
--- a/pytest-server-fixtures/pytest_server_fixtures/xvfb.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/xvfb.py
@@ -43,7 +43,10 @@ class XvfbServer(object):
 
     def __init__(self):
         tmpdir = mkdtemp(prefix='XvfbServer.', dir=Workspace.get_base_tempdir())
-        for servernum in range(os.getpid(), 65536):
+        pid_max = 65536
+        with open('/proc/sys/kernel/pid_max') as pid_max_file:
+            pid_max = int(pid_max_file.read())
+        for servernum in range(os.getpid(), pid_max):
             if os.path.exists('/tmp/.X{0}-lock'.format(servernum)):
                 continue
             self.display = ':' + str(servernum)


### PR DESCRIPTION
Since a large number of 64 bit distributions are now using larger PIDs than 65535 by default, and the xvfb fixtures makes the assumption that PIDs are going to be less than that, check what the maximum is, falling back to 65535 if we can't.