### PR TITLE
all: Remove all Python 2 requirements, such as six

### DIFF
--- a/pytest-devpi-server/_pytest_devpi_server/__init__.py
+++ b/pytest-devpi-server/_pytest_devpi_server/__init__.py
@@ -3,11 +3,11 @@ Created on 25 Apr 2012
 
 @author: eeaston
 '''
+import io
 import os
 import sys
 import zipfile
 import logging
-from six.moves import cStringIO
 
 from pytest import yield_fixture, fixture
 import devpi_server as _devpi_server
@@ -105,7 +105,7 @@ class DevpiServer(HTTPTestServer):
         client_args.extend(args)
         client_args.extend(['--clientdir', str(self.client_dir)])
         log.info(' '.join(client_args))
-        captured = cStringIO()
+        captured = io.StringIO()
         stdout = sys.stdout
         sys.stdout = captured
         try:

--- a/pytest-devpi-server/setup.py
+++ b/pytest-devpi-server/setup.py
@@ -22,7 +22,6 @@ install_requires = ['pytest-server-fixtures',
                     'pytest',
                     'devpi-server>=3.0.1',
                     'devpi-client',
-                    'six',
                     'ruamel.yaml>=0.15',
                     ]
 

--- a/pytest-fixture-config/setup.py
+++ b/pytest-fixture-config/setup.py
@@ -20,8 +20,7 @@ classifiers = [
 
 install_requires = ['pytest']
 
-tests_require = ['six',
-                 ]
+tests_require = []
 
 if __name__ == '__main__':
     kwargs = common_setup('pytest_fixture_config')

--- a/pytest-fixture-config/tests/unit/test_fixture_config.py
+++ b/pytest-fixture-config/tests/unit/test_fixture_config.py
@@ -1,11 +1,12 @@
+import importlib
+
 import pytest
-from six.moves import reload_module
 
 # HACK: if the plugin is imported before the coverage plugin then all
 # the top-level code will be omitted from coverage, so force it to be
 # reloaded within this unit test under coverage
 import pytest_fixture_config
-reload_module(pytest_fixture_config)
+importlib.reload(pytest_fixture_config)
 
 from pytest_fixture_config import Config, requires_config, yield_requires_config
 

--- a/pytest-listener/pytest_listener.py
+++ b/pytest-listener/pytest_listener.py
@@ -3,14 +3,13 @@
 import collections
 import json
 import logging
+import pickle
 import socket
 import time
 from threading import Thread, Event
 from time import sleep
 
 import pytest
-from six import string_types
-from six.moves import cPickle
 from pytest_server_fixtures.base import get_ephemeral_port, get_ephemeral_host
 
 TERMINATOR = json.dumps(['STOP']).encode('utf-8')
@@ -64,7 +63,7 @@ class TimedMsg(object):
         return 'TimedMsg: %s (@ %s)' % (str(self.value), self.time)
 
     def pickled(self):
-        return cPickle.dumps(self)
+        return pickle.dumps(self)
 
 
 class Listener(Thread):
@@ -119,7 +118,7 @@ class Listener(Thread):
             return None, None
 
         try:
-            data = cPickle.loads(data)
+            data = pickle.loads(data)
         except:
             try:
                 data = data.decode('utf-8')
@@ -133,7 +132,7 @@ class Listener(Thread):
         if isinstance(data, TimedMsg):
             d = data.value
             t = data.time
-        elif isinstance(data, string_types):
+        elif isinstance(data, str):
             try:
                 d = json.loads(data)
             except:

--- a/pytest-listener/setup.py
+++ b/pytest-listener/setup.py
@@ -18,8 +18,7 @@ classifiers = [
     'Programming Language :: Python :: 3.7',
 ]
 
-install_requires = ['six',
-                    'pytest',
+install_requires = ['pytest',
                     'pytest-server-fixtures'
                     ]
 

--- a/pytest-profiling/pytest_profiling.py
+++ b/pytest-profiling/pytest_profiling.py
@@ -1,7 +1,5 @@
 """pytest: avoid already-imported warning: PYTEST_DONT_REWRITE."""
 
-from __future__ import absolute_import
-
 import sys
 import os
 import cProfile
@@ -10,7 +8,6 @@ import errno
 from hashlib import md5
 import subprocess
 
-import six
 import pytest
 
 LARGE_FILENAME_HASH_LEN = 8
@@ -18,8 +15,8 @@ LARGE_FILENAME_HASH_LEN = 8
 
 def clean_filename(s):
     forbidden_chars = set(r'/?<>\:*|"')
-    return six.text_type("".join(c if c not in forbidden_chars and ord(c) < 127 else '_'
-                                 for c in s))
+    return str("".join(c if c not in forbidden_chars and ord(c) < 127 else '_'
+                       for c in s))
 
 
 class Profiling(object):

--- a/pytest-profiling/setup.py
+++ b/pytest-profiling/setup.py
@@ -24,8 +24,7 @@ classifiers = [
     'Programming Language :: Python :: 3.12',
 ]
 
-install_requires = ['six',
-                    'pytest',
+install_requires = ['pytest',
                     'gprof2dot',
                     ]
 

--- a/pytest-profiling/tests/unit/test_profile.py
+++ b/pytest-profiling/tests/unit/test_profile.py
@@ -2,12 +2,12 @@
 # the top-level code in pytest_profiling will be omitted from
 # coverage, so force it to be reloaded within this test unit under coverage
 
+import importlib
 import os.path
-from six.moves import reload_module  # @UnresolvedImport
 
 import pytest_profiling
 
-reload_module(pytest_profiling)
+importlib.reload(pytest_profiling)
 
 import os
 import subprocess

--- a/pytest-pyramid-server/pytest_pyramid_server.py
+++ b/pytest-pyramid-server/pytest_pyramid_server.py
@@ -3,8 +3,8 @@ Created on 25 Apr 2012
 
 @author: eeaston
 '''
+import configparser
 import os
-from six.moves import configparser
 import sys
 import socket
 import glob

--- a/pytest-pyramid-server/setup.py
+++ b/pytest-pyramid-server/setup.py
@@ -23,7 +23,6 @@ install_requires = ['pytest-server-fixtures',
                     'pytest',
                     'pyramid',
                     'waitress',
-                    'six',
                     ]
 
 tests_require = [

--- a/pytest-server-fixtures/pytest_server_fixtures/base.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/base.py
@@ -14,8 +14,6 @@ import logging
 import random
 import errno
 
-from six import string_types
-
 from pytest_server_fixtures import CONFIG
 from pytest_shutil.workspace import Workspace
 
@@ -112,7 +110,7 @@ class ProcessReader(threading.Thread):
     def run(self):
         while self.process.poll() is None:
             l = self.stream.readline()
-            if not isinstance(l, string_types):
+            if not isinstance(l, str):
                 l = l.decode('utf-8')
 
             if l.strip():

--- a/pytest-server-fixtures/pytest_server_fixtures/http.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/http.py
@@ -1,5 +1,4 @@
-from __future__ import print_function
-
+import http.client
 import os
 import socket
 import logging
@@ -9,7 +8,6 @@ import sys
 import pytest
 import requests
 from contextlib import contextmanager
-from six.moves import http_client
 
 from pytest_shutil.env import unset_env
 from pytest_server_fixtures import CONFIG
@@ -83,7 +81,7 @@ class HTTPTestServer(TestServer):
                 with self.handle_proxy():
                     returned = requests.get('http://%s:%d/%s' % (self.hostname, self.port, path))
                 return returned.json() if as_json else returned
-            except (http_client.BadStatusLine, requests.ConnectionError) as e:
+            except (http.client.BadStatusLine, requests.ConnectionError) as e:
                 time.sleep(int(i) / 10)
                 pass
         raise e
@@ -109,7 +107,7 @@ class HTTPTestServer(TestServer):
                 with self.handle_proxy():
                     returned = requests.post('http://%s:%d/%s' % (self.hostname, self.port, path), data=data, headers=headers)
                 return returned.json() if as_json else returned
-            except (http_client.BadStatusLine, requests.ConnectionError) as e:
+            except (http.client.BadStatusLine, requests.ConnectionError) as e:
                 time.sleep(int(i) / 10)
                 pass
         raise e

--- a/pytest-server-fixtures/pytest_server_fixtures/jenkins.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/jenkins.py
@@ -3,13 +3,10 @@ Created on 25 Apr 2012
 
 @author: eeaston
 '''
-from __future__ import absolute_import
-
 import os.path
 import shutil
 
 import pytest
-import six
 
 from pytest_server_fixtures import CONFIG
 from pytest_fixture_config import yield_requires_config
@@ -95,7 +92,7 @@ class JenkinsTestServer(HTTPTestServer):
         if plugins is None:
             plugins = available_plugins.keys()
         else:
-            if isinstance(plugins, six.string_types):
+            if isinstance(plugins, str):
                 plugins = [plugins]
 
             errors = []

--- a/pytest-server-fixtures/pytest_server_fixtures/postgres.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/postgres.py
@@ -1,14 +1,11 @@
 # coding: utf-8
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import os
 import logging
 import subprocess
 
 import errno
 import pytest
-from six import text_type
 
 from pytest_server_fixtures import CONFIG
 from pytest_fixture_config import requires_config
@@ -65,7 +62,7 @@ class PostgresServer(TestServer):
         try:
             self.pg_bin = subprocess.check_output([CONFIG.pg_config_executable, "--bindir"]).decode('utf-8').rstrip()
         except OSError as e:
-            msg = "Failed to get pg_config --bindir: " + text_type(e)
+            msg = "Failed to get pg_config --bindir: " + str(e)
             print(msg)
             self._fail(msg)
         initdb_path = self.pg_bin + '/initdb'
@@ -76,7 +73,7 @@ class PostgresServer(TestServer):
         try:
             subprocess.check_call([initdb_path, str(self.workspace / 'db')])
         except OSError as e:
-            msg = "Failed to launch postgres: " + text_type(e)
+            msg = "Failed to launch postgres: " + str(e)
             print(msg)
             self._fail(msg)
 

--- a/pytest-server-fixtures/pytest_server_fixtures/redis.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/redis.py
@@ -4,7 +4,6 @@ Created on 25 Apr 2012
 @author: eeaston
 
 '''
-from __future__ import absolute_import
 import socket
 
 import pytest

--- a/pytest-server-fixtures/pytest_server_fixtures/s3.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/s3.py
@@ -3,15 +3,12 @@
 Pytest fixtures to launch a minio S3 server and get a bucket for it.
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import uuid
 from collections import namedtuple
 import logging
 import os
 
 import pytest
-from future.utils import text_type
 from pytest_fixture_config import requires_config
 
 from . import CONFIG
@@ -47,7 +44,7 @@ def s3_bucket(s3_server):  # pylint: disable=redefined-outer-name
     returning a BucketInfo namedtuple with `s3_bucket.client` and `s3_bucket.name` fields
     """
     client = s3_server.get_s3_client()
-    bucket_name = text_type(uuid.uuid4())
+    bucket_name = str(uuid.uuid4())
     client.create_bucket(Bucket=bucket_name)
     return BucketInfo(client, bucket_name)
 
@@ -96,6 +93,6 @@ class MinioServer(HTTPTestServer):
             "server",
             "--address",
             "{}:{}".format(self.hostname, self.port),
-            text_type(self.datadir),
+            str(self.datadir),
         ]
         return cmdargs

--- a/pytest-server-fixtures/pytest_server_fixtures/serverclass/__init__.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/serverclass/__init__.py
@@ -2,7 +2,6 @@
 Implementation of how a server fixture will run.
 """
 # flake8: noqa
-from __future__ import absolute_import
 
 def create_server(server_class, **kwargs):
     if server_class == 'thread':

--- a/pytest-server-fixtures/pytest_server_fixtures/serverclass/docker.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/serverclass/docker.py
@@ -1,8 +1,6 @@
 """
 Docker server class implementation.
 """
-from __future__ import absolute_import
-
 import logging
 import docker
 

--- a/pytest-server-fixtures/pytest_server_fixtures/serverclass/kubernetes.py
+++ b/pytest-server-fixtures/pytest_server_fixtures/serverclass/kubernetes.py
@@ -1,7 +1,6 @@
 """
 Kubernetes server class implementation.
 """
-from __future__ import absolute_import
 
 import os
 import logging

--- a/pytest-server-fixtures/setup.py
+++ b/pytest-server-fixtures/setup.py
@@ -20,8 +20,6 @@ classifiers = [
 install_requires = ['pytest',
                     'pytest-shutil',
                     'pytest-fixture-config',
-                    'six',
-                    'future',
                     'requests',
                     'retry',
                     'psutil',

--- a/pytest-server-fixtures/tests/integration/test_s3_server.py
+++ b/pytest-server-fixtures/tests/integration/test_s3_server.py
@@ -1,7 +1,5 @@
 # coding: utf-8
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 
 def test_connection(s3_bucket):
     client, bucket_name = s3_bucket

--- a/pytest-shutil/pytest_shutil/cmdline.py
+++ b/pytest-shutil/pytest_shutil/cmdline.py
@@ -10,12 +10,6 @@ from contextlib import contextmanager
 from tempfile import mkdtemp
 
 
-try:  # Python 2
-    str_type = basestring
-except NameError:  # Python 3
-    str_type = str
-
-
 def get_log():
     return logging.getLogger(__name__)
 

--- a/pytest-shutil/pytest_shutil/workspace.py
+++ b/pytest-shutil/pytest_shutil/workspace.py
@@ -1,6 +1,5 @@
 """ Temporary directory fixtures
 """
-from __future__ import absolute_import
 import os
 import tempfile
 import shutil

--- a/pytest-shutil/setup.py
+++ b/pytest-shutil/setup.py
@@ -18,7 +18,6 @@ classifiers = [
 ]
 
 install_requires = [
-    'six',
     'execnet',
     'pytest',
     'termcolor',

--- a/pytest-shutil/tests/integration/test_run_integration.py
+++ b/pytest-shutil/tests/integration/test_run_integration.py
@@ -6,12 +6,8 @@ import pytest
 import execnet
 import inspect
 import textwrap
+from unittest import mock
 from uuid import uuid4
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 from pytest_shutil import run, workspace
 from pytest_shutil.env import no_cov

--- a/pytest-verbose-parametrize/pytest_verbose_parametrize.py
+++ b/pytest-verbose-parametrize/pytest_verbose_parametrize.py
@@ -1,12 +1,11 @@
 from collections.abc import Iterable
-from six import string_types, text_type
 
 
 def _strize_arg(arg):
     try:
         s = arg.__name__
     except AttributeError:
-        s = text_type(arg)
+        s = str(arg)
     if len(s) > 32:
         s = s[:29] + '...'
     return s
@@ -29,7 +28,7 @@ def pytest_generate_tests(metafunc):
     if 'ids' not in markers.kwargs:
         list_names = []
         for i, argvalue in enumerate(markers.args[1]):
-            if (not isinstance(argvalue, Iterable)) or isinstance(argvalue, string_types):
+            if (not isinstance(argvalue, Iterable)) or isinstance(argvalue, str):
                 argvalue = (argvalue,)
             name = '-'.join(_strize_arg(arg) for arg in argvalue)
             if len(name) > 64:

--- a/pytest-verbose-parametrize/setup.py
+++ b/pytest-verbose-parametrize/setup.py
@@ -18,11 +18,9 @@ classifiers = [
 ]
 
 install_requires = ['pytest',
-                    'six',
                     ]
 
-tests_require = ['mock; python_version<"3.3"',
-                 'pytest-virtualenv',
+tests_require = ['pytest-virtualenv',
                  'coverage',
                  ]
 

--- a/pytest-virtualenv/tests/unit/test_venv.py
+++ b/pytest-virtualenv/tests/unit/test_venv.py
@@ -1,7 +1,4 @@
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 import pytest_virtualenv as venv
 from pytest_shutil import env

--- a/pytest-webdriver/setup.py
+++ b/pytest-webdriver/setup.py
@@ -23,8 +23,7 @@ install_requires = ['py',
                     'selenium',
                     ]
 
-tests_require = ['mock; python_version<"3.3"',
-                 ]
+tests_require = []
 
 entry_points = {
     'pytest11': [


### PR DESCRIPTION
Now that the minimum version of Python required is 3.6, we can remove all uses of six and future, along with some other test changes that still support Python 2.

Fixes #209