### PR TITLE
Clean up remaining python 2

### DIFF
--- a/pytest-profiling/tests/unit/test_profile.py
+++ b/pytest-profiling/tests/unit/test_profile.py
@@ -4,6 +4,7 @@
 
 import importlib
 import os.path
+from unittest.mock import Mock, ANY, patch, sentinel, call
 
 import pytest_profiling
 
@@ -13,12 +14,6 @@ import os
 import subprocess
 
 from pytest_profiling import Profiling, pytest_addoption, pytest_configure
-
-try:
-    from unittest.mock import Mock, ANY, patch, sentinel, call
-except ImportError:
-    # python 2
-    from mock import Mock, ANY, patch, sentinel
 
 
 def test_creates_prof_dir():

--- a/pytest-server-fixtures/tests/integration/test_jenkins_server.py
+++ b/pytest-server-fixtures/tests/integration/test_jenkins_server.py
@@ -1,11 +1,7 @@
 import os.path
-from pytest import raises
+from unittest.mock import patch
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    # python 2
-    from mock import patch
+from pytest import raises
 
 
 # patch out any changes you want to the Jenkins server here:

--- a/pytest-server-fixtures/tests/integration/test_xvfb_server.py
+++ b/pytest-server-fixtures/tests/integration/test_xvfb_server.py
@@ -3,12 +3,7 @@ import subprocess
 import time
 
 from itertools import chain, repeat
-
-try:
-    from unittest.mock import patch
-except ImportError:
-    # python 2
-    from mock import patch
+from unittest.mock import patch
 
 import pytest
 from pytest import raises

--- a/pytest-server-fixtures/tests/unit/serverclass/test_docker_unit.py
+++ b/pytest-server-fixtures/tests/unit/serverclass/test_docker_unit.py
@@ -1,8 +1,4 @@
-try:
-    from unittest.mock import sentinel, patch, Mock
-except ImportError:
-    # python 2
-    from mock import sentinel, patch, Mock
+from unittest.mock import sentinel, patch, Mock
 
 from pytest_server_fixtures.serverclass.docker import DockerServer
 

--- a/pytest-server-fixtures/tests/unit/serverclass/test_kubernetes_unit.py
+++ b/pytest-server-fixtures/tests/unit/serverclass/test_kubernetes_unit.py
@@ -1,12 +1,9 @@
+from unittest.mock import sentinel, patch, Mock
+
 import pytest
 
-try:
-    from unittest.mock import sentinel, patch, Mock
-except ImportError:
-    # python 2
-    from mock import sentinel, patch, Mock
-
 from pytest_server_fixtures.serverclass.kubernetes import KubernetesServer
+
 
 @pytest.mark.skip(reason="Need a way to run this test in Kubernetes")
 @patch('pytest_server_fixtures.serverclass.docker.ServerClass.__init__')

--- a/pytest-server-fixtures/tests/unit/serverclass/test_thread_unit.py
+++ b/pytest-server-fixtures/tests/unit/serverclass/test_thread_unit.py
@@ -1,8 +1,4 @@
-try:
-    from unittest.mock import sentinel, patch, Mock
-except ImportError:
-    # python 2
-    from mock import sentinel, patch, Mock
+from unittest.mock import sentinel, patch, Mock
 
 from pytest_server_fixtures import CONFIG
 from pytest_server_fixtures.serverclass.thread import ThreadServer

--- a/pytest-server-fixtures/tests/unit/test_server_unit.py
+++ b/pytest-server-fixtures/tests/unit/test_server_unit.py
@@ -1,8 +1,4 @@
-try:
-    from unittest.mock import create_autospec, sentinel, call, patch, Mock
-except ImportError:
-    # python 2
-    from mock import create_autospec, sentinel, call, patch, Mock
+from unittest.mock import create_autospec, sentinel, call, patch, Mock
 
 from pytest_server_fixtures.base import TestServer as _TestServer  # So that pytest doesnt think this is a test case
 

--- a/pytest-server-fixtures/tests/unit/test_server_v2_unit.py
+++ b/pytest-server-fixtures/tests/unit/test_server_v2_unit.py
@@ -1,10 +1,7 @@
-try:
-    from unittest.mock import create_autospec, sentinel, call, patch, Mock
-except ImportError:
-    # python 2
-    from mock import create_autospec, sentinel, call, patch, Mock
+from unittest.mock import create_autospec, sentinel, call, patch, Mock
 
 from pytest_server_fixtures.base2 import TestServerV2 as _TestServerV2 # TODO: why as _TestServerV2?
+
 
 def test_init():
     with patch('pytest_shutil.workspace.Workspace.__init__', autospec=True) as init:

--- a/pytest-verbose-parametrize/tests/unit/test_verbose_parametrize.py
+++ b/pytest-verbose-parametrize/tests/unit/test_verbose_parametrize.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
-try:
-    from unittest.mock import Mock
-except ImportError:
-    from mock import Mock
+from unittest.mock import Mock
 
 from pytest_verbose_parametrize import pytest_generate_tests
 

--- a/pytest-webdriver/tests/integration/test_integration.py
+++ b/pytest-webdriver/tests/integration/test_integration.py
@@ -1,8 +1,4 @@
-try:
-    from unittest.mock import Mock, sentinel, patch
-except ImportError:
-    # python 2
-    from mock import Mock, sentinel, patch
+from unittest.mock import Mock, sentinel, patch
 
 import pytest
 import selenium

--- a/pytest-webdriver/tests/unit/test_webdriver.py
+++ b/pytest-webdriver/tests/unit/test_webdriver.py
@@ -1,8 +1,4 @@
-try:
-    from unittest.mock import Mock, sentinel, patch
-except ImportError:
-    # python 2
-    from mock import Mock, sentinel, patch
+from unittest.mock import Mock, sentinel, patch
 
 import pytest
 import selenium


### PR DESCRIPTION
In pytest-profiling, python-server-fixtures, python-verbose-parametrize and python-webdriver, clean up remaining Python 2 code, which was all falling back to `mock` from `unittest.mock`.